### PR TITLE
Remove coveralls reporting [ATLAS-759]

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,5 +1,5 @@
 ## Communicating with other developers
 
 pullrequests for all packages.
-- [GitHub issues](https://github.com/wooga/atlas-snyk/issues): All discussions around bugs, feature requests.
-- [GitHub pull requests](https://github.com/wooga/atlas-snyk/pulls): All discussions bugfixes, important and new additions.
+- [GitHub issues](https://github.com/wooga/atlas-snyk-gradle-plugin/issues): All discussions around bugs, feature requests.
+- [GitHub pull requests](https://github.com/wooga/atlas-snyk-gradle-plugin/pulls): All discussions bugfixes, important and new additions.

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '3.1.0'
+    id 'net.wooga.plugins' version '4.0.0'
     id 'net.wooga.snyk' version '0.10.0'
     id "net.wooga.snyk-gradle-plugin" version "0.2.0"
     id "net.wooga.cve-dependency-resolution" version "0.4.0"
@@ -50,6 +50,6 @@ cveHandler {
 
 dependencies {
     implementation 'com.wooga.gradle:gradle-commons:[1,2['
-    implementation "net.wooga.gradle:atlas-snyk:0.10.0"
+    implementation "net.wooga.gradle:snyk:0.11.0"
     testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2['
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,4 +27,4 @@ pluginManagement {
   }
 }
 
-rootProject.name = 'atlas-snyk-gradle-plugin'
+rootProject.name = 'snyk-gradle-plugin'


### PR DESCRIPTION
## Description

Because of security issues reported for the coveralls gradle plugin I decided to remove the feature during build. It is not enough to just stop sending reports via jenkins. We also need to update to `net.wooga.plugins` > `4.0.0` because this version removes the dependency.

I remove the coveralls token in the Jenkinsfile so our base pipeline won't try to call the coveralls task on the gradle project.

## Changes

* ![UPDATE] `net.wooga.plugins` to version `4.0.0` to remove coveralls dependency
* ![REMOVE] coveralls token in Jenkinsfile

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
