### PR TITLE
Switch to wooga frontend organisation [ATLAS-937]

### DIFF
--- a/src/main/groovy/wooga/gradle/snyk/gradle/GradlePluginSnykConventionPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/snyk/gradle/GradlePluginSnykConventionPlugin.groovy
@@ -59,7 +59,7 @@ class GradlePluginSnykConventionPlugin implements Plugin<Project> {
             SnykConventions.strategies.defaultValue = toString([SnykPlugin.MONITOR_CHECK])
             SnykConventions.failOn.defaultValue = toString(FailOnOption.all)
             SnykConventions.severityThreshold.defaultValue = toString(SeverityThresholdOption.high)
-            SnykConventions.orgName.defaultValue = "wooga-pipeline"
+            SnykConventions.orgName.defaultValue = "wooga"
         })
     }
 

--- a/src/test/groovy/wooga/gradle/snyk/gradle/GradlePluginSnykConventionPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/snyk/gradle/GradlePluginSnykConventionPluginSpec.groovy
@@ -70,7 +70,7 @@ class GradlePluginSnykConventionPluginSpec extends ProjectSpec {
         snykExtension.strategies.get() == [SnykPlugin.MONITOR_CHECK]
         snykExtension.failOn.get() == FailOnOption.all
         snykExtension.severityThreshold.get() == SeverityThresholdOption.high
-        snykExtension.orgName.get() == "wooga-pipeline"
+        snykExtension.orgName.get() == "wooga"
 
         where:
         applyAfter | message


### PR DESCRIPTION
## Description

Out frontend projects switched from the `wooga-pipeline` org to the `wooga` organization with the official name `Wooga Frontend`.

## Changes

* ![CHANGE] default snyk organization from `wooga-pipeline` to `wooga`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
